### PR TITLE
Fix lifecycle to visible on didPop

### DIFF
--- a/lib/src/lifecycle_observer.dart
+++ b/lib/src/lifecycle_observer.dart
@@ -76,6 +76,7 @@ class LifecycleObserver extends NavigatorObserver with WidgetsBindingObserver {
   @override
   void didChangeAppLifecycleState(AppLifecycleState state) {
     super.didChangeAppLifecycleState(state);
+    log('LifecycleObserver($hashCode)#state:${state.toString()}');
     // log(state.toString());
     if (_routes.isEmpty || _lifecycleSubscribers.isEmpty) return;
     switch (state) {
@@ -142,8 +143,8 @@ class LifecycleObserver extends NavigatorObserver with WidgetsBindingObserver {
 
     if (previousRoute != null) {
       if (route is PageRoute) {
-        // 上一个 Route 触发 active
-        _sendEventToGivenRoute(previousRoute, LifecycleEvent.active);
+        // 上一个 Route 触发 visible
+        _sendEventToGivenRoute(previousRoute, LifecycleEvent.visible);
         if (previousRoute is PopupRoute) {
           // 上一个 PageRoute 触发 visible
           _sendEventToLastPageRoute(LifecycleEvent.visible);


### PR DESCRIPTION
问题：A页面push到B页面时，A -> invisible,   从B页面pop时， A -> active， 这里A的状态应该是visible

invisible应该和visible对应，active与inactive对应上， 这样处理一些业务逻辑才比较方便，如统计页面的显示时长
